### PR TITLE
Add sort by CP and Name. Fixes #12

### DIFF
--- a/app/api/sort.js
+++ b/app/api/sort.js
@@ -40,13 +40,16 @@ export default {
   },
 
   name(items) {
-      return _.sortBy(items, (v) => {
-          if (typeof v.nickname !== "undefined" && v.nickname !== "") {
-              return v.nickname;
-          } else {
-              return v.meta.name;
-          }
-      });
+    return _.sortBy(
+      _.sortBy(items, (v) => -v.cp),
+      (v) => {
+        if (typeof v.nickname !== "undefined" && v.nickname !== "") {
+          return v.nickname;
+        } else {
+          return v.meta.name;
+        }
+      }
+    );
   },
 
 };

--- a/app/api/sort.js
+++ b/app/api/sort.js
@@ -34,4 +34,9 @@ export default {
       (v) => v.pokemon_id
     );
   },
+
+  cp(items) {
+    return _.sortBy(items, (v) => -v.cp);
+  },
+
 };

--- a/app/api/sort.js
+++ b/app/api/sort.js
@@ -39,4 +39,14 @@ export default {
     return _.sortBy(items, (v) => -v.cp);
   },
 
+  name(items) {
+      return _.sortBy(items, (v) => {
+          if (typeof v.nickname !== "undefined" && v.nickname !== "") {
+              return v.nickname;
+          } else {
+              return v.meta.name;
+          }
+      });
+  },
+
 };

--- a/app/components/Journal.js
+++ b/app/components/Journal.js
@@ -57,6 +57,7 @@ export default class Journal extends Component {
               <MenuItem value="recent" primaryText="Recent" />
               <MenuItem value="id" primaryText="Pokemon ID" />
               <MenuItem value="iv" primaryText="IV" />
+              <MenuItem value="cp" primaryText="CP" />
             </DropDownMenu>
           </ToolbarGroup>
         </Toolbar>

--- a/app/components/Journal.js
+++ b/app/components/Journal.js
@@ -58,6 +58,7 @@ export default class Journal extends Component {
               <MenuItem value="id" primaryText="Pokemon ID" />
               <MenuItem value="iv" primaryText="IV" />
               <MenuItem value="cp" primaryText="CP" />
+              <MenuItem value="name" primaryText="Name" />
             </DropDownMenu>
           </ToolbarGroup>
         </Toolbar>


### PR DESCRIPTION
The sort by Name tries to mimic the official app: first it uses the nickname, them the pokemon name. When the name is the same, sort by CP
